### PR TITLE
fix(models): remove default value from isComplete

### DIFF
--- a/src/models/todo.model.ts
+++ b/src/models/todo.model.ts
@@ -1,5 +1,5 @@
-import { Entity, property, model } from '@loopback/repository';
-import { SchemaObject } from '@loopback/openapi-spec';
+import {Entity, property, model} from '@loopback/repository';
+import {SchemaObject} from '@loopback/openapi-spec';
 
 @model()
 export class Todo extends Entity {
@@ -23,7 +23,7 @@ export class Todo extends Entity {
   @property({
     type: 'boolean'
   })
-  isComplete: boolean = false;
+  isComplete: boolean;
 
   getId() {
     return this.id;

--- a/test/acceptance/application.test.ts
+++ b/test/acceptance/application.test.ts
@@ -47,7 +47,8 @@ describe('Application', () => {
     const todo = await givenTodoInstance();
     const updatedTodo = givenTodo({
       title: 'DO SOMETHING AWESOME',
-      desc: 'It has to be something ridiculous'
+      desc: 'It has to be something ridiculous',
+      isComplete: true
     });
     await client
       .put(`/todo/${todo.id}`)
@@ -60,7 +61,8 @@ describe('Application', () => {
   it('updates the todo by ID ', async () => {
     const todo = await givenTodoInstance();
     const updatedTodo = givenTodo({
-      title: 'DO SOMETHING AWESOME'
+      title: 'DO SOMETHING AWESOME',
+      isComplete: true
     });
     await client
       .patch(`/todo/${todo.id}`)


### PR DESCRIPTION
The legacy juggler bridge does not handle default values well,
so the isComplete field will no longer use a default value of false.
Test coverage has been added to verify that the field is correctly
updated on PUT and PATCH requests.